### PR TITLE
Map reroute when clicked

### DIFF
--- a/events/static/events/js/script.js
+++ b/events/static/events/js/script.js
@@ -53,7 +53,7 @@ async function initMap() {
                 var eventNameDiv = document.createElement('div');
                 eventNameDiv.className = "eventnameDiv";
                 eventNameDiv.addEventListener("click", function(e){
-                    window.location.href += `${locEvent.id}`;
+                    window.location.href = window.location.origin+"/events/"+`${locEvent.id}`;
                 });
                 eventNameDiv.innerHTML = `${locEvent.name}`+"\n";
                 


### PR DESCRIPTION
Added a small change when you click on the event on the map it takes you to its event page properly.