### PR TITLE
make event tag clickable and functioning as a filter

### DIFF
--- a/events/templates/events/event-detail.html
+++ b/events/templates/events/event-detail.html
@@ -41,7 +41,7 @@
 .join-entry-text {
     flex-grow: 1;
 }
-.Tags{
+.tags{
     display: flex;
 }
 .Tag{
@@ -136,6 +136,14 @@ ul {
     background-color: #0056b3;
 }
 
+.tag-button {
+    background-color: rgba(255,255,255,0.3);
+}
+
+.tag-button:hover {
+    background-color: rgba(255,255,255,0.7);
+}
+
 
 </style>
 
@@ -162,19 +170,19 @@ ul {
             <div class="event-detail-container mb-4">
                 <div class="sticky-note-container">
                     <div class="my-3"><h1>{{ event.event_name }}</h1></div>
+                    {% if event.tags.all %}
+                        <div class="tags row row-cols-auto px-2">
+                            {% for tag in event.tags.all %}
+                                <a href="{% url 'events:event-detail' event_id=event.id %}?filter_tag={{ tag.id }}" class="col btn btn-sm rounded-pill tag-button mb-2 mx-1 px-2">{{ tag }}</a>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
                     <h4>Creator</h4>
                     <p>{{ event.creator }}</p>
                     <h4>Date and Time</h4>
                     <p>from {{ event.start_time }} to {{ event.end_time }}</p>
                     <!-- <img src="event-image.jpg" alt="Event Image" class="img-fluid rounded"> -->
-                    <h4>Tags</h4>
-                    <div class="Tags">
-                    {% for tag in event.tags.all %}
-                    <p class = "Tag">{{ tag }}</p>
-                    {% empty %}
-                    <p class = "Tag">None</p>
-                    {% endfor %}
-                    </div>
+                    
                     <h4>Location</h4>
                     <p>{{ location }}, {{ location.address }} ({{ location.category }})</p>
                     <h4>Capacity</h4>

--- a/events/views.py
+++ b/events/views.py
@@ -378,6 +378,10 @@ def deleteEvent(request, event_id):
 
 
 def eventDetail(request, event_id):
+    if request.method == "GET":
+        if "filter_tag" in request.GET:
+            tag_label = request.GET.get("filter_tag", "")
+            return filter_event_tag_label(tag_label)
     event = get_object_or_404(Event, pk=event_id)
     if not event.is_active:
         messages.warning(request, "The event is deleted. Try some other events!")


### PR DESCRIPTION
![image](https://github.com/gcivil-nyu-org/Wednesday-Fall2023-Team-3/assets/130470692/5c786348-b892-4509-ac6a-892c51d06449)

clicking on the tag button will direct the user to the filtered event lists
![image](https://github.com/gcivil-nyu-org/Wednesday-Fall2023-Team-3/assets/130470692/aa644220-4f8f-4724-82e4-add42bf365ca)
 